### PR TITLE
NewAdminBundle: Fixed get search_text returning null

### DIFF
--- a/src/Pumukit/NewAdminBundle/Resources/config/routes/mms.yml
+++ b/src/Pumukit/NewAdminBundle/Resources/config/routes/mms.yml
@@ -137,11 +137,10 @@ pumukitnewadmin_mms_getchildrentag:
         _controller: PumukitNewAdminBundle:MultimediaObject:getChildrenTag
 
 pumukitnewadmin_mms_searchtag:
-    path: /search/{search_text}
+    path: /search
     methods: [GET, POST]
     defaults:
         _controller: PumukitNewAdminBundle:MultimediaObject:searchTag
-        search_text:
 
 pumukitnewadmin_mms_list:
     path: /list


### PR DESCRIPTION
If the routing configuration defines an attribute, when calling request->get() the attribute has preference over the get/post parameters
Since here we NEVER call the route like this, we always got null as result, since the attribute was always null