### PR TITLE
TTK-22977 SchemaBundle: Always return something in getAbsoluteUrl

### DIFF
--- a/src/Pumukit/SchemaBundle/Services/PicService.php
+++ b/src/Pumukit/SchemaBundle/Services/PicService.php
@@ -334,20 +334,20 @@ class PicService
      */
     protected function getAbsoluteUrlPic($picUrl = '')
     {
-        if ($picUrl) {
-            if ('/' == $picUrl[0]) {
-                $scheme = $this->context->getScheme();
-                $host = $this->context->getHost();
-                $port = '';
-                if ('http' === $scheme && 80 != $this->context->getHttpPort()) {
-                    $port = ':'.$this->context->getHttpPort();
-                } elseif ('https' === $scheme && 443 != $this->context->getHttpsPort()) {
-                    $port = ':'.$this->context->getHttpsPort();
-                }
-
-                return $scheme.'://'.$host.$port.$picUrl;
-            }
+        if (!$picUrl || '/' != $picUrl[0]) {
+            return $picUrl;
         }
+
+        $scheme = $this->context->getScheme();
+        $host = $this->context->getHost();
+        $port = '';
+        if ('http' === $scheme && 80 != $this->context->getHttpPort()) {
+            $port = ':'.$this->context->getHttpPort();
+        } elseif ('https' === $scheme && 443 != $this->context->getHttpsPort()) {
+            $port = ':'.$this->context->getHttpsPort();
+        }
+
+        return $scheme.'://'.$host.$port.$picUrl;
     }
 
     /**


### PR DESCRIPTION
At some point with previous refactors (see commit: be2ac51ed6) this function lost a default return.
* Added default return if the url is not absolute.
* Turned if statements into exit clauses (may prevent this kind of mistake in the future)