### PR TITLE
TTK-23035 SchemaBundle: Returned empty string if  is null

### DIFF
--- a/src/Pumukit/SchemaBundle/Document/Material.php
+++ b/src/Pumukit/SchemaBundle/Document/Material.php
@@ -103,6 +103,6 @@ class Material extends Element
      */
     public function getLanguage()
     {
-        return $this->language;
+        return $this->language ?? '';
     }
 }


### PR DESCRIPTION
This at least keeps type consistency while we don't implement strict construct() methods that don't allow initializing Materials with empty values as required